### PR TITLE
feat(app-storefront): add Facebook Pixel tracking

### DIFF
--- a/app-storefront/.env.local
+++ b/app-storefront/.env.local
@@ -15,3 +15,6 @@ NEXT_PUBLIC_STRIPE_KEY=
 
 # Your Next.js revalidation secret. See – https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#on-demand-revalidation
 REVALIDATE_SECRET=supersecret
+
+# Facebook Pixel ID
+NEXT_PUBLIC_FACEBOOK_PIXEL_ID=578129907772466

--- a/app-storefront/README.md
+++ b/app-storefront/README.md
@@ -110,6 +110,14 @@ NEXT_PUBLIC_STRIPE_KEY=<your-stripe-public-key>
 
 You'll also need to setup the integrations in your Medusa server. See the [Medusa documentation](https://docs.medusajs.com) for more information on how to configure [Stripe](https://docs.medusajs.com/resources/commerce-modules/payment/payment-provider/stripe#main).
 
+# Analytics
+
+To enable Facebook Pixel tracking, add the following to your `.env.local` file:
+
+```
+NEXT_PUBLIC_FACEBOOK_PIXEL_ID=<your-facebook-pixel-id>
+```
+
 # Resources
 
 ## Learn more about Medusa

--- a/app-storefront/check-env-variables.js
+++ b/app-storefront/check-env-variables.js
@@ -7,6 +7,10 @@ const requiredEnvs = [
     description:
       "Learn how to create a publishable key: https://docs.medusajs.com/v2/resources/storefront-development/publishable-api-keys",
   },
+  {
+    key: "NEXT_PUBLIC_FACEBOOK_PIXEL_ID",
+    description: "Facebook Pixel ID used for Meta Pixel tracking",
+  },
 ]
 
 function checkEnvVariables() {

--- a/app-storefront/src/app/layout.tsx
+++ b/app-storefront/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { getBaseURL } from "@lib/util/env"
 import { Metadata } from "next"
 import "styles/globals.css"
+import FacebookPixel from "@modules/analytics/components/facebook-pixel"
 
 export const metadata: Metadata = {
   metadataBase: new URL(getBaseURL()),
@@ -10,6 +11,7 @@ export default function RootLayout(props: { children: React.ReactNode }) {
   return (
     <html lang="en" data-mode="light">
       <body>
+        <FacebookPixel />
         <main className="relative">{props.children}</main>
       </body>
     </html>

--- a/app-storefront/src/modules/analytics/components/facebook-pixel/index.tsx
+++ b/app-storefront/src/modules/analytics/components/facebook-pixel/index.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import Script from 'next/script'
+import { usePathname, useSearchParams } from 'next/navigation'
+import { useEffect, useRef } from 'react'
+
+const FB_PIXEL_ID = process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID
+
+function FacebookPixel() {
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const firstRun = useRef(true)
+
+  useEffect(() => {
+    if (!FB_PIXEL_ID) {
+      return
+    }
+
+    if (firstRun.current) {
+      firstRun.current = false
+      return
+    }
+
+    // Track pageview on route changes
+    if (typeof window !== 'undefined' && (window as any).fbq) {
+      ;(window as any).fbq('track', 'PageView')
+    }
+  }, [pathname, searchParams])
+
+  if (!FB_PIXEL_ID) {
+    return null
+  }
+
+  return (
+    <>
+      <Script id='facebook-pixel' strategy='afterInteractive'>
+        {`!function(f,b,e,v,n,t,s)
+          {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+          n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+          n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t,s)}(window, document,'script',
+          'https://connect.facebook.net/en_US/fbevents.js');
+          fbq('init', '${FB_PIXEL_ID}');
+          fbq('track', 'PageView');`}
+      </Script>
+      <noscript>
+        <img
+          height='1'
+          width='1'
+          style={{ display: 'none' }}
+          src={`https://www.facebook.com/tr?id=${FB_PIXEL_ID}&ev=PageView&noscript=1`}
+        />
+      </noscript>
+    </>
+  )
+}
+
+export default FacebookPixel
+


### PR DESCRIPTION
## Summary
- add Facebook Pixel ID env variable and docs
- inject Meta Pixel tracking script into storefront layout
- require pixel ID in env check

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [x] No cross‑module imports; using container & links correctly.
- [x] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [x] README includes install/config/usage with examples.
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [x] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68be7a8aaf5883318f56f847c0a87a61