### PR TITLE
feat(app-storefront): redesign hero section

### DIFF
--- a/app-storefront/src/modules/home/components/hero/index.tsx
+++ b/app-storefront/src/modules/home/components/hero/index.tsx
@@ -1,33 +1,38 @@
-import { Github } from "@medusajs/icons"
 import { Button, Heading } from "@medusajs/ui"
 
 const Hero = () => {
   return (
-    <div className="h-[75vh] w-full border-b border-ui-border-base relative bg-ui-bg-subtle">
-      <div className="absolute inset-0 z-10 flex flex-col justify-center items-center text-center small:p-32 gap-6">
-        <span>
-          <Heading
-            level="h1"
-            className="text-3xl leading-10 text-ui-fg-base font-normal"
-          >
-            Ecommerce Starter Template
-          </Heading>
-          <Heading
-            level="h2"
-            className="text-3xl leading-10 text-ui-fg-subtle font-normal"
-          >
-            Powered by Medusa and Next.js
-          </Heading>
-        </span>
-        <a
-          href="https://github.com/medusajs/nextjs-starter-medusa"
-          target="_blank"
+    <div className="h-[75vh] w-full border-b border-ui-border-base relative bg-ui-bg-interactive">
+      <div className="absolute inset-0 z-10 flex flex-col justify-center items-center text-center px-4 gap-6">
+        <Heading
+          level="h1"
+          className="text-3xl leading-10 text-ui-fg-on-color font-normal max-w-3xl"
         >
-          <Button variant="secondary">
-            View on GitHub
-            <Github />
-          </Button>
-        </a>
+          Modern marketplace platform without limits
+        </Heading>
+        <Heading
+          level="h2"
+          className="text-base text-ui-fg-on-color/80 font-normal max-w-2xl"
+        >
+          Open source marketplace platform to build and resell tech. Modern
+          tech, unlimited customization, no transaction fees.
+        </Heading>
+        <div className="flex items-center gap-4 mt-4">
+          <a href="https://cal.com/medusajs" target="_blank">
+            <Button variant="primary">Schedule demo</Button>
+          </a>
+          <a
+            href="https://github.com/medusajs/nextjs-starter-medusa"
+            target="_blank"
+          >
+            <Button
+              variant="transparent"
+              className="text-ui-fg-on-color border border-ui-border-interactive"
+            >
+              Visit GitHub
+            </Button>
+          </a>
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- redesign homepage hero content and layout to new marketing copy

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68be7f57b33c833198575378506e2821