### PR TITLE
feat(app-storefront): add case study section to home

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next"
 import FeaturedProducts from "@modules/home/components/featured-products"
 import Hero from "@modules/home/components/hero"
 import Features from "@modules/home/components/features"
+import CaseStudy from "@modules/home/components/case-study"
 import { listCollections } from "@lib/data/collections"
 import { getRegion } from "@lib/data/regions"
 
@@ -33,6 +34,7 @@ export default async function Home(props: {
     <>
       <Hero />
       <Features />
+      <CaseStudy />
       <div className="py-12">
         <ul className="flex flex-col gap-x-6">
           <FeaturedProducts collections={collections} region={region} />

--- a/app-storefront/src/modules/home/components/case-study/index.tsx
+++ b/app-storefront/src/modules/home/components/case-study/index.tsx
@@ -1,0 +1,48 @@
+import { Button, Heading, Text } from "@medusajs/ui"
+
+const CaseStudy = () => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 border-b border-ui-border-base">
+      <div
+        className="flex items-center justify-center p-8"
+        style={{ backgroundColor: "#2A0C6A" }}
+      >
+        <div className="w-full max-w-md aspect-video bg-ui-bg-base" />
+      </div>
+      <div className="flex flex-col justify-center p-8 gap-6">
+        <Heading level="h3" className="text-base">natuja</Heading>
+        <Heading level="h2" className="text-2xl font-medium">
+          Custom Marketplace built in 9 Weeks
+        </Heading>
+        <Text className="text-base text-ui-fg-subtle">
+          Natuja, a rising star in the DACH marketplace for natural products,
+          migrated from Sharetribe platform to a customized Medusa Marketplace
+          Platform.
+        </Text>
+        <div className="flex gap-8">
+          <div>
+            <Heading level="h4" className="text-2xl font-medium">
+              1000+
+            </Heading>
+            <Text className="text-small-regular text-ui-fg-muted">
+              Products
+            </Text>
+          </div>
+          <div>
+            <Heading level="h4" className="text-2xl font-medium">
+              150+
+            </Heading>
+            <Text className="text-small-regular text-ui-fg-muted">
+              Vendors
+            </Text>
+          </div>
+        </div>
+        <div>
+          <Button>Explore Case Study</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CaseStudy


### PR DESCRIPTION
## Summary
- add case study component highlighting Natuja marketplace
- surface case study on home page below feature highlights

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross‑module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68be8621e86c8331a9e180a2648b3467