### PR TITLE
feat(app-storefront): add guide section to home page

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/page.tsx
@@ -4,6 +4,7 @@ import FeaturedProducts from "@modules/home/components/featured-products"
 import Hero from "@modules/home/components/hero"
 import Features from "@modules/home/components/features"
 import CaseStudy from "@modules/home/components/case-study"
+import Guide from "@modules/home/components/guide"
 import { listCollections } from "@lib/data/collections"
 import { getRegion } from "@lib/data/regions"
 
@@ -33,6 +34,7 @@ export default async function Home(props: {
   return (
     <>
       <Hero />
+      <Guide />
       <Features />
       <CaseStudy />
       <div className="py-12">

--- a/app-storefront/src/modules/home/components/guide/index.tsx
+++ b/app-storefront/src/modules/home/components/guide/index.tsx
@@ -1,0 +1,37 @@
+import { Button, Heading, Text } from "@medusajs/ui"
+
+const Guide = () => {
+  return (
+    <div className="border-b border-ui-border-base bg-ui-bg-base">
+      <div className="content-container py-12">
+        <div className="grid grid-cols-1 md:grid-cols-2 items-center gap-8">
+          <div className="flex flex-col gap-6">
+            <Heading level="h2" className="text-3xl font-medium">
+              Guide: B2B Food Marketplace
+            </Heading>
+            <Text className="text-base text-ui-fg-subtle">
+              Read how you can build B2B Marketplace with Mercur. Explore free ebook now.
+            </Text>
+            <div className="flex items-center gap-4">
+              <Button className="bg-[#2A0C6A] text-white hover:bg-[#2A0C6A]">
+                Download Guide
+              </Button>
+              <Button
+                variant="transparent"
+                className="border border-[#2A0C6A] text-[#2A0C6A]"
+              >
+                Read online
+              </Button>
+            </div>
+          </div>
+          <div className="flex justify-center">
+            <div className="w-full max-w-md aspect-[4/3] bg-ui-bg-subtle" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Guide
+


### PR DESCRIPTION
## Summary
- add new Guide section component with call to action
- include Guide section on home page after hero

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

## 7) PR Gate (copy into PR description)
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68be8b7f633883318d22fa8e15e77da8