### PR TITLE
feat(storefront): add commerce modules section to homepage

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/page.tsx
@@ -4,6 +4,7 @@ import FeaturedProducts from "@modules/home/components/featured-products"
 import Hero from "@modules/home/components/hero"
 import Features from "@modules/home/components/features"
 import CaseStudy from "@modules/home/components/case-study"
+import CommerceModules from "@modules/home/components/commerce-modules"
 import Guide from "@modules/home/components/guide"
 import { listCollections } from "@lib/data/collections"
 import { getRegion } from "@lib/data/regions"
@@ -37,6 +38,7 @@ export default async function Home(props: {
       <Guide />
       <Features />
       <CaseStudy />
+      <CommerceModules />
       <div className="py-12">
         <ul className="flex flex-col gap-x-6">
           <FeaturedProducts collections={collections} region={region} />

--- a/app-storefront/src/modules/home/components/commerce-modules/index.tsx
+++ b/app-storefront/src/modules/home/components/commerce-modules/index.tsx
@@ -1,0 +1,105 @@
+import {
+  CubeSolid,
+  ShoppingCart,
+  User,
+  CreditCard,
+  TruckFast,
+  ChartBar,
+  Users,
+} from "@medusajs/icons"
+import { Heading, Text } from "@medusajs/ui"
+
+const topIcons = [
+  CubeSolid,
+  ShoppingCart,
+  User,
+  CreditCard,
+  TruckFast,
+  ChartBar,
+]
+
+const cards = [
+  {
+    icon: ShoppingCart,
+    title: "Cart",
+    description: "Add to cart, checkout, and totals",
+  },
+  {
+    icon: CreditCard,
+    title: "Payment",
+    description: "Process any payment type",
+  },
+  {
+    icon: Users,
+    title: "Customer",
+    description: "B2C and B2B customer accounts",
+  },
+]
+
+const CommerceModules = () => {
+  return (
+    <div className="border-b border-ui-border-base bg-ui-bg-base">
+      <div className="content-container flex flex-col gap-12 py-12">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          <div className="flex flex-col gap-4">
+            <Text className="text-small-regular text-ui-fg-subtle">
+              Commerce Modules
+            </Text>
+            <Heading level="h2" className="text-2xl font-medium">
+              Modules covering all commerce domains
+            </Heading>
+          </div>
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-wrap gap-2">
+              {topIcons.map((Icon, i) => (
+                <div
+                  key={i}
+                  className="flex h-9 w-9 items-center justify-center rounded-md bg-ui-bg-subtle"
+                >
+                  <Icon className="h-5 w-5 text-ui-fg-subtle" />
+                </div>
+              ))}
+            </div>
+            <Text className="text-base text-ui-fg-subtle">
+              Pre-built commerce logic in composable modules. Adopt
+              incrementally, compose as you want.
+            </Text>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+          <div className="flex flex-col gap-4">
+            <Heading level="h3" className="text-xl font-medium">
+              Cart &amp; Purchase
+            </Heading>
+            <Text className="text-base text-ui-fg-subtle">
+              Checkout, total calculations, and more
+            </Text>
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {cards.map(({ icon: Icon, title, description }) => (
+              <div
+                key={title}
+                className="flex flex-col gap-2 rounded-lg border border-ui-border-base bg-ui-bg-base p-4"
+              >
+                <div className="flex items-center gap-2">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-md bg-ui-bg-subtle">
+                    <Icon className="h-4 w-4 text-ui-fg-subtle" />
+                  </div>
+                  <Heading level="h4" className="text-base font-medium">
+                    {title}
+                  </Heading>
+                </div>
+                <Text className="text-small-regular text-ui-fg-muted">
+                  {description}
+                </Text>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CommerceModules


### PR DESCRIPTION
## Summary
- add commerce modules section featuring module icons and cart/purchase cards
- render commerce modules section after case study on storefront homepage

## Testing
- `yarn lint` (fails: Error while loading rule '@next/next/no-html-link-for-pages')
- `yarn build` (fails: useSearchParams() should be wrapped in a suspense boundary)

## PR Gate Checklist
- [x] Correctly chose **Module** or **Plugin** per the decision flow.
- [x] No cross-module imports; using container & links correctly.
- [x] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [x] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68be8df487ac8331b7dc426b2a44c5ed