### PR TITLE
feat(frontend): add marketplace demo cta

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/page.tsx
@@ -6,6 +6,7 @@ import Features from "@modules/home/components/features"
 import CaseStudy from "@modules/home/components/case-study"
 import CommerceModules from "@modules/home/components/commerce-modules"
 import Guide from "@modules/home/components/guide"
+import DemoCta from "@modules/home/components/demo-cta"
 import { listCollections } from "@lib/data/collections"
 import { getRegion } from "@lib/data/regions"
 
@@ -44,6 +45,7 @@ export default async function Home(props: {
           <FeaturedProducts collections={collections} region={region} />
         </ul>
       </div>
+      <DemoCta />
     </>
   )
 }

--- a/app-storefront/src/modules/common/icons/mercur.tsx
+++ b/app-storefront/src/modules/common/icons/mercur.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { IconProps } from "types/icon"
+
+const Mercur: React.FC<IconProps> = ({ size = "32", ...attributes }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      fill="none"
+      {...attributes}
+    >
+      <defs>
+        <linearGradient
+          id="mercur-gradient"
+          x1="0"
+          y1="0"
+          x2="32"
+          y2="32"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0%" stopColor="#8B5CF6" />
+          <stop offset="100%" stopColor="#2A0C6A" />
+        </linearGradient>
+      </defs>
+      <path
+        d="M6 6H12L16 13L20 6H26V26H20V17L16 24L12 17V26H6V6Z"
+        fill="url(#mercur-gradient)"
+      />
+    </svg>
+  )
+}
+
+export default Mercur

--- a/app-storefront/src/modules/home/components/demo-cta/index.tsx
+++ b/app-storefront/src/modules/home/components/demo-cta/index.tsx
@@ -1,0 +1,39 @@
+import { Button, Heading, Text } from "@medusajs/ui"
+import { ArrowUpRightMini } from "@medusajs/icons"
+import Mercur from "@modules/common/icons/mercur"
+
+const DemoCta = () => {
+  return (
+    <div className="border-y border-ui-border-base bg-ui-bg-base">
+      <div className="content-container flex flex-col items-center text-center gap-6 py-16">
+        <Mercur className="h-10 w-10" />
+        <Heading level="h2" className="text-3xl font-medium">
+          Build custom marketplace with Mercur
+        </Heading>
+        <Text className="text-base text-ui-fg-subtle max-w-2xl">
+          Schedule a quick call to get our Mercur Marketplace tailored to your specific marketplace requirements. Connect with our team to discuss how we can help bring your marketplace vision to life.
+        </Text>
+        <div className="flex items-center gap-4 mt-4">
+          <a href="https://cal.com/medusajs" target="_blank">
+            <Button className="bg-[#2A0C6A] text-white hover:bg-[#2A0C6A]">
+              Schedule demo
+            </Button>
+          </a>
+          <a
+            href="https://github.com/medusajs/nextjs-starter-medusa"
+            target="_blank"
+            className="flex items-center gap-1 text-[#2A0C6A] group"
+          >
+            <span>Github</span>
+            <ArrowUpRightMini
+              className="transition-transform group-hover:rotate-45"
+              color="#2A0C6A"
+            />
+          </a>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default DemoCta


### PR DESCRIPTION
## Summary
- add Mercur gradient logo icon
- add home page call-to-action with schedule demo and GitHub link
- include call-to-action section on storefront home page

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*
- `yarn build` *(fails: useSearchParams() should be wrapped in a suspense boundary at page "/404"...)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross‑module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68be9295c33c83319061298aa3d688ed