### PR TITLE
feat: add pricing section to storefront home page

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/page.tsx
@@ -8,6 +8,7 @@ import CommerceModules from "@modules/home/components/commerce-modules"
 import Guide from "@modules/home/components/guide"
 import Faq from "@modules/home/components/faq"
 import DemoCta from "@modules/home/components/demo-cta"
+import Pricing from "@modules/home/components/pricing"
 import { listCollections } from "@lib/data/collections"
 import { getRegion } from "@lib/data/regions"
 
@@ -46,6 +47,7 @@ export default async function Home(props: {
           <FeaturedProducts collections={collections} region={region} />
         </ul>
       </div>
+      <Pricing />
       <Faq />
       <DemoCta />
     </>

--- a/app-storefront/src/modules/home/components/pricing/index.tsx
+++ b/app-storefront/src/modules/home/components/pricing/index.tsx
@@ -1,0 +1,89 @@
+import { Button, Heading, Text } from "@medusajs/ui"
+
+const plans = [
+  {
+    name: "Hobby",
+    description:
+      "The perfect starting place for your side or personal project. Free forever.",
+    features: [
+      "Automatic SSL",
+      "Custom domains",
+      "Global edge network",
+      "Previews",
+      "Git integration",
+      "Edge functions",
+      "Instant rollbacks",
+      "Usage analytics",
+    ],
+    cta: "Start developing",
+  },
+  {
+    name: "Pro",
+    description:
+      "Everything you need to build your business. $20/mo per member.",
+    features: [
+      "Everything in Hobby",
+      "AI-powered analytics",
+      "Enhanced collaboration",
+      "Faster builds",
+      "Advanced speed insights",
+      "Email support",
+    ],
+    cta: "Start the trial",
+  },
+  {
+    name: "Enterprise",
+    description:
+      "Critical security, performance, observability, and support.",
+    features: [
+      "Everything in Pro",
+      "SSO & team access controls",
+      "SOC 2 & security management",
+      "99.99% uptime SLA",
+      "Build and usage analytics",
+      "Dedicated support",
+    ],
+    cta: "Request trial",
+  },
+]
+
+const Pricing = () => {
+  return (
+    <div className="border-b border-ui-border-base bg-ui-bg-base">
+      <div className="content-container py-12">
+        <div className="flex flex-col items-center text-center">
+          <Heading level="h2" className="text-3xl font-medium">
+            Find a plan to power your apps.
+          </Heading>
+          <Text className="mt-2 text-ui-fg-subtle">
+            Vercel supports teams of all sizes, with pricing that scales.
+          </Text>
+        </div>
+        <div className="mt-12 grid grid-cols-1 gap-8 md:grid-cols-3">
+          {plans.map(({ name, description, features, cta }) => (
+            <div
+              key={name}
+              className="flex flex-col rounded-md border border-ui-border-base p-6"
+            >
+              <Heading level="h3" className="text-xl font-medium">
+                {name}
+              </Heading>
+              <Text className="mt-2 text-ui-fg-subtle">{description}</Text>
+              <ul className="mt-6 flex-1 list-disc pl-5 text-ui-fg-subtle">
+                {features.map((feature) => (
+                  <li key={feature} className="text-small-regular">
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+              <Button className="mt-6">{cta}</Button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Pricing
+


### PR DESCRIPTION
## Summary
- add pricing section with plan cards to home page
- display section above FAQs

## Testing
- `npm run lint` (fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [x] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68be97971a288331bb8b5c3ad5f6fdea