### PR TITLE
feat(app-storefront): add start button to header

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/page.tsx
@@ -38,8 +38,8 @@ export default async function Home(props: {
   return (
     <>
       <Hero />
-      <Guide />
       <Features />
+      <Guide />
       <CaseStudy />
       <CommerceModules />
       <div className="py-12">

--- a/app-storefront/src/modules/layout/templates/nav/index.tsx
+++ b/app-storefront/src/modules/layout/templates/nav/index.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react"
 
 import { listRegions } from "@lib/data/regions"
 import { StoreRegion } from "@medusajs/types"
+import { Button } from "@medusajs/ui"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import CartButton from "@modules/layout/components/cart-button"
 import SideMenu from "@modules/layout/components/side-menu"
@@ -12,7 +13,7 @@ export default async function Nav() {
   return (
     <div className="sticky top-0 inset-x-0 z-50 group">
       <header className="relative h-16 mx-auto border-b duration-200 bg-white border-ui-border-base">
-        <nav className="content-container txt-xsmall-plus text-ui-fg-subtle flex items-center justify-between w-full h-full text-small-regular">
+        <nav className="content-container text-ui-fg-subtle flex items-center justify-between w-full h-full text-large-regular">
           <div className="flex-1 basis-0 h-full flex items-center">
             <div className="h-full">
               <SideMenu regions={regions} />
@@ -52,6 +53,9 @@ export default async function Nav() {
             >
               <CartButton />
             </Suspense>
+            <Button asChild>
+              <LocalizedClientLink href="/start">Start for Free</LocalizedClientLink>
+            </Button>
           </div>
         </nav>
       </header>


### PR DESCRIPTION
## Summary
- add "Start for Free" button after cart in header
- reposition features section directly below hero
- set header typography to 16px for improved readability

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

## PR Gate
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68beb7aecd948331a858025ef3282f27