### PR TITLE
feat(storefront): redesign footer

### DIFF
--- a/app-storefront/src/modules/common/icons/linkedin.tsx
+++ b/app-storefront/src/modules/common/icons/linkedin.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { IconProps } from "types/icon"
+
+const Linkedin: React.FC<IconProps> = ({ size = "20", color = "currentColor", ...attributes }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 15 15"
+      fill="none"
+      {...attributes}
+    >
+      <path
+        d="M11.438.75H3.561A2.813 2.813 0 0 0 .75 3.563v7.874a2.813 2.813 0 0 0 2.813 2.813h7.874a2.81 2.81 0 0 0 2.813-2.812V3.561A2.81 2.81 0 0 0 11.438.75M5.25 11.438H3.563V5.25H5.25zm-.844-6.901a.99.99 0 0 1-.984-.992c0-.548.44-.993.984-.993s.985.445.985.993c0 .547-.44.992-.985.992m7.594 6.9h-1.687V8.285c0-1.894-2.25-1.75-2.25 0v3.153H6.375V5.25h1.688v.993C8.848 4.788 12 4.68 12 7.636z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+export default Linkedin

--- a/app-storefront/src/modules/common/icons/youtube.tsx
+++ b/app-storefront/src/modules/common/icons/youtube.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import { IconProps } from "types/icon"
+
+const Youtube: React.FC<IconProps> = ({ size = "20", color = "currentColor", ...attributes }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      {...attributes}
+    >
+      <path
+        d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"
+        fill={color}
+      />
+    </svg>
+  )
+}
+
+export default Youtube

--- a/app-storefront/src/modules/layout/templates/footer/index.tsx
+++ b/app-storefront/src/modules/layout/templates/footer/index.tsx
@@ -1,155 +1,104 @@
-import { listCategories } from "@lib/data/categories"
-import { listCollections } from "@lib/data/collections"
-import { Text, clx } from "@medusajs/ui"
+import { Text } from "@medusajs/ui"
 
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
-import MedusaCTA from "@modules/layout/components/medusa-cta"
+import Mercur from "@modules/common/icons/mercur"
+import Linkedin from "@modules/common/icons/linkedin"
+import X from "@modules/common/icons/x"
+import Youtube from "@modules/common/icons/youtube"
 
-export default async function Footer() {
-  const { collections } = await listCollections({
-    fields: "*products",
-  })
-  const productCategories = await listCategories()
-
+export default function Footer() {
   return (
     <footer className="border-t border-ui-border-base w-full">
-      <div className="content-container flex flex-col w-full">
-        <div className="flex flex-col gap-y-6 xsmall:flex-row items-start justify-between py-40">
-          <div>
+      <div className="content-container flex flex-col w-full py-12 gap-y-8">
+        <div className="grid grid-cols-1 xsmall:grid-cols-3 items-center gap-y-6">
+          <LocalizedClientLink
+            href="/"
+            className="flex items-center gap-x-2 justify-self-start"
+          >
+            <Mercur className="h-6 w-6" />
+            <span className="txt-compact-medium text-ui-fg-base">Mercur</span>
+          </LocalizedClientLink>
+          <nav className="flex items-center justify-center gap-x-6">
             <LocalizedClientLink
-              href="/"
-              className="txt-compact-xlarge-plus text-ui-fg-subtle hover:text-ui-fg-base uppercase"
+              href="#"
+              className="text-ui-fg-subtle hover:text-ui-fg-base txt-small"
             >
-              Medusa Store
+              About
             </LocalizedClientLink>
-          </div>
-          <div className="text-small-regular gap-10 md:gap-x-16 grid grid-cols-2 sm:grid-cols-3">
-            {productCategories && productCategories?.length > 0 && (
-              <div className="flex flex-col gap-y-2">
-                <span className="txt-small-plus txt-ui-fg-base">
-                  Categories
-                </span>
-                <ul
-                  className="grid grid-cols-1 gap-2"
-                  data-testid="footer-categories"
-                >
-                  {productCategories?.slice(0, 6).map((c) => {
-                    if (c.parent_category) {
-                      return
-                    }
-
-                    const children =
-                      c.category_children?.map((child) => ({
-                        name: child.name,
-                        handle: child.handle,
-                        id: child.id,
-                      })) || null
-
-                    return (
-                      <li
-                        className="flex flex-col gap-2 text-ui-fg-subtle txt-small"
-                        key={c.id}
-                      >
-                        <LocalizedClientLink
-                          className={clx(
-                            "hover:text-ui-fg-base",
-                            children && "txt-small-plus"
-                          )}
-                          href={`/categories/${c.handle}`}
-                          data-testid="category-link"
-                        >
-                          {c.name}
-                        </LocalizedClientLink>
-                        {children && (
-                          <ul className="grid grid-cols-1 ml-3 gap-2">
-                            {children &&
-                              children.map((child) => (
-                                <li key={child.id}>
-                                  <LocalizedClientLink
-                                    className="hover:text-ui-fg-base"
-                                    href={`/categories/${child.handle}`}
-                                    data-testid="category-link"
-                                  >
-                                    {child.name}
-                                  </LocalizedClientLink>
-                                </li>
-                              ))}
-                          </ul>
-                        )}
-                      </li>
-                    )
-                  })}
-                </ul>
-              </div>
-            )}
-            {collections && collections.length > 0 && (
-              <div className="flex flex-col gap-y-2">
-                <span className="txt-small-plus txt-ui-fg-base">
-                  Collections
-                </span>
-                <ul
-                  className={clx(
-                    "grid grid-cols-1 gap-2 text-ui-fg-subtle txt-small",
-                    {
-                      "grid-cols-2": (collections?.length || 0) > 3,
-                    }
-                  )}
-                >
-                  {collections?.slice(0, 6).map((c) => (
-                    <li key={c.id}>
-                      <LocalizedClientLink
-                        className="hover:text-ui-fg-base"
-                        href={`/collections/${c.handle}`}
-                      >
-                        {c.title}
-                      </LocalizedClientLink>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            <div className="flex flex-col gap-y-2">
-              <span className="txt-small-plus txt-ui-fg-base">Medusa</span>
-              <ul className="grid grid-cols-1 gap-y-2 text-ui-fg-subtle txt-small">
-                <li>
-                  <a
-                    href="https://github.com/medusajs"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="hover:text-ui-fg-base"
-                  >
-                    GitHub
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="https://docs.medusajs.com"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="hover:text-ui-fg-base"
-                  >
-                    Documentation
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="https://github.com/medusajs/nextjs-starter-medusa"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="hover:text-ui-fg-base"
-                  >
-                    Source code
-                  </a>
-                </li>
-              </ul>
-            </div>
+            <LocalizedClientLink
+              href="#"
+              className="text-ui-fg-subtle hover:text-ui-fg-base txt-small"
+            >
+              Features
+            </LocalizedClientLink>
+            <LocalizedClientLink
+              href="#"
+              className="text-ui-fg-subtle hover:text-ui-fg-base txt-small"
+            >
+              Contact
+            </LocalizedClientLink>
+            <a
+              href="https://docs.medusajs.com"
+              target="_blank"
+              rel="noreferrer"
+              className="text-ui-fg-subtle hover:text-ui-fg-base txt-small"
+            >
+              Docs
+            </a>
+            <a
+              href="https://github.com/medusajs/nextjs-starter-medusa"
+              target="_blank"
+              rel="noreferrer"
+              className="text-ui-fg-subtle hover:text-ui-fg-base txt-small"
+            >
+              GitHub
+            </a>
+          </nav>
+          <div className="flex items-center gap-x-2 justify-self-end">
+            <a
+              href="https://www.linkedin.com"
+              target="_blank"
+              rel="noreferrer"
+              className="flex h-10 w-10 items-center justify-center rounded-rounded bg-ui-bg-subtle text-ui-fg-muted hover:text-ui-fg-base"
+            >
+              <Linkedin className="h-4 w-4" />
+            </a>
+            <a
+              href="https://x.com"
+              target="_blank"
+              rel="noreferrer"
+              className="flex h-10 w-10 items-center justify-center rounded-rounded bg-ui-bg-subtle text-ui-fg-muted hover:text-ui-fg-base"
+            >
+              <X className="h-4 w-4" />
+            </a>
+            <a
+              href="https://www.youtube.com"
+              target="_blank"
+              rel="noreferrer"
+              className="flex h-10 w-10 items-center justify-center rounded-rounded bg-ui-bg-subtle text-ui-fg-muted hover:text-ui-fg-base"
+            >
+              <Youtube className="h-4 w-4" />
+            </a>
           </div>
         </div>
-        <div className="flex w-full mb-16 justify-between text-ui-fg-muted">
+        <div className="flex flex-col xsmall:flex-row items-center w-full justify-between gap-y-4 text-ui-fg-muted">
           <Text className="txt-compact-small">
-            © {new Date().getFullYear()} Medusa Store. All rights reserved.
+            © {new Date().getFullYear()} Mercur. All rights reserved.
           </Text>
-          <MedusaCTA />
+          <div className="flex items-center gap-x-4">
+            <LocalizedClientLink
+              href="#"
+              className="hover:text-ui-fg-base"
+            >
+              Cookie Settings
+            </LocalizedClientLink>
+            <LocalizedClientLink
+              href="#"
+              className="hover:text-ui-fg-base"
+            >
+              Privacy Policy
+            </LocalizedClientLink>
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).

## Summary
- redesigned footer: brand, navigation links, social icons, and policy links
- added LinkedIn and YouTube icon components for reuse

## Testing
- `npm run lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string)*

------
https://chatgpt.com/codex/tasks/task_e_68beba3ed970833197b146179edb939f