### PR TITLE
feat: add support section to pricing page

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/pricing/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/pricing/page.tsx
@@ -59,6 +59,27 @@ const plans = [
   },
 ] as const
 
+const supportFeatures = [
+  "Discovery sessions",
+  "Technical architecture guidance",
+  "Pairing sessions with Solution Engineer",
+  "Dedicated Slack channel",
+  "Dedicated support",
+  "Integrated technical resources to manage project-level aspects",
+  "Dedicated Delivery Lead",
+  "Quarterly business review sessions",
+] as const
+
+const unlimitedFeatures = [
+  "Unlimited Stores",
+  "Unlimited Integrations",
+  "Unlimited Layouts / UI",
+  "Unlimited Datastreams",
+  "Unlimited Environments",
+  "Unlimited Inventory Locations",
+  "Unlimited Storage",
+] as const
+
 export const metadata: Metadata = {
   title: "Pricing",
 }
@@ -123,6 +144,39 @@ const PricingPage = () => {
             </Text>
           </div>
         ))}
+      </div>
+      <div className="mt-16 rounded-xl border bg-ui-bg-base p-8 text-center shadow-elevation-card-rest">
+        <Heading level="h2" className="text-xl font-medium">
+          Included in each Saver Cloud plan
+        </Heading>
+        <Text className="mt-2 text-ui-fg-subtle">
+          All Cloud customers are provided ongoing Delivery and support help to help accelerate discovery and implementation.
+        </Text>
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          {supportFeatures.map((feature) => (
+            <Badge key={feature} color="orange" className="text-small-regular">
+              {feature}
+            </Badge>
+          ))}
+        </div>
+        <Text className="mt-10 text-ui-fg-subtle">
+          Unlimited access to the commerce feature-sets in your theme without artificial constraints.
+        </Text>
+        <div className="mt-6 flex flex-wrap justify-center gap-3">
+          {unlimitedFeatures.map((feature) => (
+            <Badge
+              key={feature}
+              color="green"
+              className="flex items-center gap-1 text-small-regular"
+            >
+              <CheckMini className="h-4 w-4" />
+              {feature}
+            </Badge>
+          ))}
+        </div>
+        <Text className="mt-2 text-small-regular text-ui-fg-subtle">
+          *Unlimited resources are subject to fair usage policies.
+        </Text>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- add shared support details and unlimited feature highlights to pricing page

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages')*

## PR Gate
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68bf43f17878833195031522849b5672