### PR TITLE
fix(pricing): update advantage check icons

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/pricing/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/pricing/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next"
 import { Badge, Button, Heading, Table, Text } from "@medusajs/ui"
-import { CheckMini } from "@medusajs/icons"
+import { CheckMini, CheckCircleSolid } from "@medusajs/icons"
 
 const plans = [
   {
@@ -270,11 +270,11 @@ const PricingPage = () => {
                   {advantage.title}
                 </Table.Cell>
                 <Table.Cell className="text-center">
-                  <CheckMini className="mx-auto h-5 w-5 text-green-500" />
+                  <CheckCircleSolid className="mx-auto h-5 w-5 text-green-500" />
                 </Table.Cell>
                 <Table.Cell className="text-center">
                   {advantage.openSource === "check" && (
-                    <CheckMini className="mx-auto h-5 w-5 text-ui-fg-interactive" />
+                    <CheckCircleSolid className="mx-auto h-5 w-5 text-ui-fg-interactive" />
                   )}
                   {advantage.openSource === "self-managed" && (
                     <Text className="text-small-regular text-ui-fg-subtle">


### PR DESCRIPTION
## Summary
- replace check icons with `CheckCircleSolid` in pricing advantages table

## Testing
- `npm run lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

## PR Gate
- [x] Correctly chose **Module** or **Plugin** per the decision flow.
- [x] No cross‑module imports; using container & links correctly.
- [x] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent (N/A).
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples (N/A).
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied (N/A).
- [x] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68bf800bedfc83319a42c7ddc792dca0