### PR TITLE
feat: replace commerce experience icons

### DIFF
--- a/app-storefront/src/modules/home/components/commerce-experience/index.tsx
+++ b/app-storefront/src/modules/home/components/commerce-experience/index.tsx
@@ -1,38 +1,35 @@
 import { Heading, Text } from "@medusajs/ui"
-import { Component, ArrowsPointingOut, GridList } from "@medusajs/icons"
+import Image from "next/image"
 
 const colorMap = {
   blue: {
     bg: "bg-ui-tag-blue-bg",
-    icon: "text-ui-tag-blue-icon",
   },
   green: {
     bg: "bg-ui-tag-green-bg",
-    icon: "text-ui-tag-green-icon",
   },
   purple: {
     bg: "bg-ui-tag-purple-bg",
-    icon: "text-ui-tag-purple-icon",
   },
 } as const
 
 const features = [
   {
-    icon: Component,
+    image: "/commerce-engine.svg",
     title: "Powerful Commerce Engine",
     description:
       "Build with Commerce Modules like Product, Promotions or Checkout to compose your perfect stack.",
     color: "blue" as const,
   },
   {
-    icon: ArrowsPointingOut,
+    image: "/unrivalled-extensibility.svg",
     title: "Unrivaled Extensibility",
     description:
       "Extend your commerce stack with any integration and your business logic across the backend, API, or any frontend.",
     color: "green" as const,
   },
   {
-    icon: GridList,
+    image: "/user-friendly-dashboard.svg",
     title: "User-Friendly Dashboard",
     description:
       "An operational dashboard for merchants, customers, and the community. Extend with custom apps as you grow.",
@@ -48,7 +45,7 @@ const CommerceExperience = () => {
           Take full control of your commerce experience
         </Heading>
         <div className="mt-8 grid grid-cols-1 gap-6 md:grid-cols-3">
-          {features.map(({ icon: Icon, title, description, color }) => (
+          {features.map(({ image, title, description, color }) => (
             <div
               key={title}
               className="flex flex-col items-center gap-4 rounded-lg border border-ui-border-base p-6 text-center"
@@ -56,7 +53,13 @@ const CommerceExperience = () => {
               <div
                 className={`flex h-16 w-16 items-center justify-center rounded-md ${colorMap[color].bg}`}
               >
-                <Icon className={`h-8 w-8 ${colorMap[color].icon}`} />
+                <Image
+                  src={image}
+                  alt={title}
+                  width={32}
+                  height={32}
+                  className="h-8 w-8 object-contain"
+                />
               </div>
               <Heading level="h3" className="text-lg font-medium">
                 {title}


### PR DESCRIPTION
## Summary
- replace commerce experience icons with SVG images

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

## PR Gate
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68bf8e28b8e08331b26b6e365218d666