### PR TITLE
feat(app-storefront): add chat widget script to home page

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next"
+import Script from "next/script"
 
 import FeaturedProducts from "@modules/home/components/featured-products"
 import Hero from "@modules/home/components/hero"
@@ -39,6 +40,21 @@ export default async function Home(props: {
 
   return (
     <>
+      <Script id="chatwoot-script" strategy="lazyOnload">
+        {`(function(d,t) {
+    var BASE_URL="http://91.99.198.182:3000";
+    var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+    g.src=BASE_URL+"/packs/js/sdk.js";
+    g.async = true;
+    s.parentNode.insertBefore(g,s);
+    g.onload=function(){
+      window.chatwootSDK.run({
+        websiteToken: 'oBf1gBsAco2ZJUAhbqS1akh3',
+        baseUrl: BASE_URL
+      })
+    }
+  })(document,"script");`}
+      </Script>
       <Hero />
       <Features />
       <CommerceExperience />


### PR DESCRIPTION
## Summary
- add Chatwoot script to storefront home page

## Testing
- `npm run lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages')*

## PR Gate Checklist
- [x] Correctly chose **Module** or **Plugin** per the decision flow.
- [x] No cross‑module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [x] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c08c21b6fc83318e8a3a654ab3765d