### PR TITLE
feat: add tenant signup page

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/tenant-signup/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/tenant-signup/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next"
+import TenantSignup from "@modules/tenant/components/signup"
+
+export const metadata: Metadata = {
+  title: "Tenant signup",
+  description: "Create a new tenant account.",
+}
+
+export default function TenantSignupPage() {
+  return (
+    <div className="w-full flex justify-start px-8 py-8">
+      <TenantSignup />
+    </div>
+  )
+}
+

--- a/app-storefront/src/modules/layout/components/mobile-menu/index.tsx
+++ b/app-storefront/src/modules/layout/components/mobile-menu/index.tsx
@@ -98,6 +98,14 @@ const MobileMenu = ({
                 Developer
               </LocalizedClientLink>
               <LocalizedClientLink
+                href="/tenant-signup"
+                onClick={() => setOpen(false)}
+                className="block py-4"
+                data-testid="mobile-tenant-signup-link"
+              >
+                Tenant Signup
+              </LocalizedClientLink>
+              <LocalizedClientLink
                 href="/account"
                 onClick={() => setOpen(false)}
                 className="block py-4"

--- a/app-storefront/src/modules/layout/templates/nav/index.tsx
+++ b/app-storefront/src/modules/layout/templates/nav/index.tsx
@@ -51,6 +51,13 @@ export default async function Nav() {
               </LocalizedClientLink>
               <LocalizedClientLink
                 className="hover:text-ui-fg-base"
+                href="/tenant-signup"
+                data-testid="nav-tenant-signup-link"
+              >
+                Tenant Signup
+              </LocalizedClientLink>
+              <LocalizedClientLink
+                className="hover:text-ui-fg-base"
                 href="/account"
                 data-testid="nav-account-link"
               >

--- a/app-storefront/src/modules/tenant/components/signup/index.tsx
+++ b/app-storefront/src/modules/tenant/components/signup/index.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { useActionState } from "react"
+import Input from "@modules/common/components/input"
+import ErrorMessage from "@modules/checkout/components/error-message"
+import { SubmitButton } from "@modules/checkout/components/submit-button"
+import { signup } from "@lib/data/customer"
+
+const TenantSignup = () => {
+  const [message, formAction] = useActionState(signup, null)
+
+  return (
+    <div className="max-w-sm flex flex-col items-center" data-testid="tenant-signup-page">
+      <h1 className="text-large-semi uppercase mb-6">Create your tenant account</h1>
+      <form className="w-full flex flex-col" action={formAction}>
+        <div className="flex flex-col w-full gap-y-2">
+          <Input label="First name" name="first_name" required autoComplete="given-name" />
+          <Input label="Last name" name="last_name" required autoComplete="family-name" />
+          <Input label="Email" name="email" required type="email" autoComplete="email" />
+          <Input label="Phone" name="phone" type="tel" autoComplete="tel" />
+          <Input label="Password" name="password" required type="password" autoComplete="new-password" />
+          <Input label="Subdomain" name="subdomain" required autoComplete="off" />
+        </div>
+        <ErrorMessage error={message} data-testid="tenant-signup-error" />
+        <SubmitButton className="w-full mt-6" data-testid="tenant-signup-button">
+          Sign up
+        </SubmitButton>
+      </form>
+    </div>
+  )
+}
+
+export default TenantSignup
+


### PR DESCRIPTION
## Summary
- add dedicated tenant signup form and page
- link tenant signup in navigation and mobile menu

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages')*
- `yarn build` *(fails: useSearchParams should be wrapped in a suspense boundary)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross‑module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c5c8c170688331afeb5ff1e3e4b12c