### PR TITLE
fix(frontend): send tenant creation as JSON during signup

### DIFF
--- a/app-storefront/src/lib/data/customer.ts
+++ b/app-storefront/src/lib/data/customer.ts
@@ -90,11 +90,14 @@ export async function signup(_currentState: unknown, formData: FormData) {
     if (subdomain) {
       await sdk.client.fetch(`/store/tenants`, {
         method: "POST",
+        headers: {
+          ...headers,
+          "Content-Type": "application/json",
+        },
         body: {
           owner_id: createdCustomer.id,
           subdomain,
         },
-        headers,
       })
     }
 


### PR DESCRIPTION
## Summary
- ensure tenant signup sends JSON body

## Testing
- `npm run test:integration:http` *(fails: Error initializing database)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c5cbf9bc4c8331a59ce33ed9ec44a9