### PR TITLE
feat(storefront): add tenant login and password reset

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/tenant-login/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/tenant-login/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next"
+import TenantLogin from "@modules/tenant/components/login"
+
+export const metadata: Metadata = {
+  title: "Tenant login",
+  description: "Sign in to your tenant account.",
+}
+
+export default function TenantLoginPage() {
+  return (
+    <div className="w-full flex justify-start px-8 py-8">
+      <TenantLogin />
+    </div>
+  )
+}
+

--- a/app-storefront/src/app/[countryCode]/(main)/tenant-reset-password/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/tenant-reset-password/page.tsx
@@ -1,0 +1,16 @@
+import { Metadata } from "next"
+import TenantResetPassword from "@modules/tenant/components/reset-password"
+
+export const metadata: Metadata = {
+  title: "Reset tenant password",
+  description: "Request a password reset and set a new password.",
+}
+
+export default function TenantResetPasswordPage() {
+  return (
+    <div className="w-full flex justify-start px-8 py-8">
+      <TenantResetPassword />
+    </div>
+  )
+}
+

--- a/app-storefront/src/lib/data/customer.ts
+++ b/app-storefront/src/lib/data/customer.ts
@@ -142,6 +142,40 @@ export async function login(_currentState: unknown, formData: FormData) {
   }
 }
 
+export async function requestPasswordReset(
+  _currentState: unknown,
+  formData: FormData
+) {
+  const email = formData.get("email") as string
+
+  try {
+    await sdk.auth.resetPassword("customer", "emailpass", {
+      identifier: email,
+    })
+  } catch (error: any) {
+    return error.toString()
+  }
+}
+
+export async function resetPassword(
+  _currentState: unknown,
+  formData: FormData
+) {
+  const token = formData.get("token") as string
+  const password = formData.get("password") as string
+
+  try {
+    await sdk.auth.updateProvider(
+      "customer",
+      "emailpass",
+      { password },
+      token
+    )
+  } catch (error: any) {
+    return error.toString()
+  }
+}
+
 export async function signout(countryCode: string) {
   await sdk.auth.logout()
 

--- a/app-storefront/src/modules/layout/components/mobile-menu/index.tsx
+++ b/app-storefront/src/modules/layout/components/mobile-menu/index.tsx
@@ -106,6 +106,14 @@ const MobileMenu = ({
                 Tenant Signup
               </LocalizedClientLink>
               <LocalizedClientLink
+                href="/tenant-login"
+                onClick={() => setOpen(false)}
+                className="block py-4"
+                data-testid="mobile-tenant-login-link"
+              >
+                Tenant Login
+              </LocalizedClientLink>
+              <LocalizedClientLink
                 href="/account"
                 onClick={() => setOpen(false)}
                 className="block py-4"

--- a/app-storefront/src/modules/layout/templates/nav/index.tsx
+++ b/app-storefront/src/modules/layout/templates/nav/index.tsx
@@ -58,6 +58,13 @@ export default async function Nav() {
               </LocalizedClientLink>
               <LocalizedClientLink
                 className="hover:text-ui-fg-base"
+                href="/tenant-login"
+                data-testid="nav-tenant-login-link"
+              >
+                Tenant Login
+              </LocalizedClientLink>
+              <LocalizedClientLink
+                className="hover:text-ui-fg-base"
                 href="/account"
                 data-testid="nav-account-link"
               >

--- a/app-storefront/src/modules/tenant/components/login/index.tsx
+++ b/app-storefront/src/modules/tenant/components/login/index.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { useActionState } from "react"
+import LocalizedClientLink from "@modules/common/components/localized-client-link"
+import Input from "@modules/common/components/input"
+import ErrorMessage from "@modules/checkout/components/error-message"
+import { SubmitButton } from "@modules/checkout/components/submit-button"
+import { login } from "@lib/data/customer"
+
+const TenantLogin = () => {
+  const [message, formAction] = useActionState(login, null)
+
+  return (
+    <div className="max-w-sm flex flex-col items-center" data-testid="tenant-login-page">
+      <h1 className="text-large-semi uppercase mb-6">Tenant Login</h1>
+      <form className="w-full" action={formAction}>
+        <div className="flex flex-col w-full gap-y-2">
+          <Input label="Email" name="email" required type="email" autoComplete="email" />
+          <Input
+            label="Password"
+            name="password"
+            required
+            type="password"
+            autoComplete="current-password"
+          />
+        </div>
+        <ErrorMessage error={message} data-testid="tenant-login-error" />
+        <SubmitButton className="w-full mt-6" data-testid="tenant-login-button">
+          Sign in
+        </SubmitButton>
+      </form>
+      <LocalizedClientLink
+        href="/tenant-reset-password"
+        className="underline mt-6"
+        data-testid="tenant-forgot-password-link"
+      >
+        Forgot password?
+      </LocalizedClientLink>
+    </div>
+  )
+}
+
+export default TenantLogin
+

--- a/app-storefront/src/modules/tenant/components/reset-password/index.tsx
+++ b/app-storefront/src/modules/tenant/components/reset-password/index.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useActionState, useState } from "react"
+import Input from "@modules/common/components/input"
+import ErrorMessage from "@modules/checkout/components/error-message"
+import { SubmitButton } from "@modules/checkout/components/submit-button"
+import { requestPasswordReset, resetPassword } from "@lib/data/customer"
+
+const TenantResetPassword = () => {
+  const [step, setStep] = useState<"request" | "reset">("request")
+  const [requestMessage, requestAction] = useActionState(requestPasswordReset, null)
+  const [resetMessage, resetAction] = useActionState(resetPassword, null)
+
+  return (
+    <div className="max-w-sm flex flex-col items-center" data-testid="tenant-reset-password-page">
+      <h1 className="text-large-semi uppercase mb-6">Reset Password</h1>
+      {step === "request" ? (
+        <form
+          className="w-full flex flex-col"
+          action={async (formData) => {
+            const res = await requestAction(formData)
+            if (!res) {
+              setStep("reset")
+            }
+          }}
+        >
+          <Input label="Email" name="email" type="email" required autoComplete="email" />
+          <ErrorMessage error={requestMessage} data-testid="tenant-reset-request-error" />
+          <SubmitButton className="w-full mt-6" data-testid="tenant-reset-request-button">
+            Send reset email
+          </SubmitButton>
+        </form>
+      ) : (
+        <form className="w-full flex flex-col" action={resetAction}>
+          <Input label="Token" name="token" required autoComplete="off" />
+          <Input
+            label="New password"
+            name="password"
+            type="password"
+            required
+            autoComplete="new-password"
+          />
+          <ErrorMessage error={resetMessage} data-testid="tenant-reset-error" />
+          <SubmitButton className="w-full mt-6" data-testid="tenant-reset-button">
+            Reset password
+          </SubmitButton>
+        </form>
+      )}
+    </div>
+  )
+}
+
+export default TenantResetPassword
+


### PR DESCRIPTION
## Summary
- add tenant login page with link from navigation
- allow tenants to request and complete password resets
- expose tenant login and reset options in mobile menu

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

## PR Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c5ce052db88331ba738e89ec7ec026