### PR TITLE
fix: handle tenant signup state

### DIFF
--- a/app-storefront/src/lib/data/customer.ts
+++ b/app-storefront/src/lib/data/customer.ts
@@ -59,7 +59,10 @@ export const updateCustomer = async (body: HttpTypes.StoreUpdateCustomer) => {
   return updateRes
 }
 
-export async function signup(_currentState: unknown, formData: FormData) {
+export async function signup(
+  _currentState: unknown,
+  formData: FormData
+): Promise<string | null> {
   const password = formData.get("password") as string
   const customerForm = {
     email: formData.get("email") as string,
@@ -113,7 +116,7 @@ export async function signup(_currentState: unknown, formData: FormData) {
 
     await transferCart()
 
-    return createdCustomer
+    return null
   } catch (error: any) {
     return error.toString()
   }


### PR DESCRIPTION
## Summary
- return null instead of customer object on successful signup

## Testing
- ⚠️ `yarn lint` (Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)

## PR Gate
- [x] Correctly chose **Module** or **Plugin** per the decision flow.
- [x] No cross‑module imports; using container & links correctly.
- [x] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [x] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c5d444d01c8331a36ab0dc1b1dbe23