### PR TITLE
feat: generate tenant subdomains automatically

### DIFF
--- a/app-storefront/src/lib/data/customer.ts
+++ b/app-storefront/src/lib/data/customer.ts
@@ -70,7 +70,6 @@ export async function signup(
     last_name: formData.get("last_name") as string,
     phone: formData.get("phone") as string,
   }
-  const subdomain = formData.get("subdomain") as string
 
   try {
     const token = await sdk.auth.register("customer", "emailpass", {
@@ -90,19 +89,16 @@ export async function signup(
       headers
     )
 
-    if (subdomain) {
-      await sdk.client.fetch(`/store/tenants`, {
-        method: "POST",
-        headers: {
-          ...headers,
-          "Content-Type": "application/json",
-        },
-        body: {
-          owner_id: createdCustomer.id,
-          subdomain,
-        },
-      })
-    }
+    await sdk.client.fetch(`/store/tenants`, {
+      method: "POST",
+      headers: {
+        ...headers,
+        "Content-Type": "application/json",
+      },
+      body: {
+        owner_id: createdCustomer.id,
+      },
+    })
 
     const loginToken = await sdk.auth.login("customer", "emailpass", {
       email: customerForm.email,

--- a/app-storefront/src/lib/data/tenant.ts
+++ b/app-storefront/src/lib/data/tenant.ts
@@ -19,7 +19,6 @@ export async function tenantSignup(
     last_name: formData.get("last_name") as string,
     phone: formData.get("phone") as string,
   }
-  const subdomain = formData.get("subdomain") as string
 
   try {
     const token = await sdk.auth.register("user", "emailpass", {
@@ -39,13 +38,10 @@ export async function tenantSignup(
       last_name: userForm.last_name,
       phone: userForm.phone,
     })
-
-    if (subdomain) {
-      await sdk.client.fetch(`/store/tenants`, {
-        method: "POST",
-        body: { owner_id: ownerId, subdomain },
-      })
-    }
+    await sdk.client.fetch(`/store/tenants`, {
+      method: "POST",
+      body: { owner_id: ownerId },
+    })
 
     const loginToken = await sdk.auth.login("user", "emailpass", {
       email: userForm.email,

--- a/app-storefront/src/modules/tenant/components/signup/index.tsx
+++ b/app-storefront/src/modules/tenant/components/signup/index.tsx
@@ -25,7 +25,6 @@ const TenantSignup = () => {
           <Input label="Email" name="email" required type="email" autoComplete="email" />
           <Input label="Phone" name="phone" type="tel" autoComplete="tel" />
           <Input label="Password" name="password" required type="password" autoComplete="new-password" />
-          <Input label="Subdomain" name="subdomain" required autoComplete="off" />
         </div>
         {state.success && (
           <div

--- a/app/integration-tests/http/tenant.spec.ts
+++ b/app/integration-tests/http/tenant.spec.ts
@@ -11,12 +11,23 @@ medusaIntegrationTestRunner({
       it("creates and retrieves tenant", async () => {
         const response = await api.post("/store/tenants", {
           owner_id: "owner1",
-          subdomain: "test-shop",
         })
         expect(response.status).toEqual(200)
         const tenantService = container.resolve(TENANT_MODULE)
-        const tenant = await tenantService.retrieveBySubdomain("test-shop")
+        const tenant = await tenantService.retrieveBySubdomain(
+          response.data.tenant.subdomain
+        )
         expect(tenant).toBeTruthy()
+      })
+
+      it("generates unique subdomains when none provided", async () => {
+        const first = await api.post("/store/tenants", { owner_id: "owner2" })
+        const second = await api.post("/store/tenants", { owner_id: "owner2" })
+        expect(first.status).toEqual(200)
+        expect(second.status).toEqual(200)
+        expect(first.data.tenant.subdomain).not.toEqual(
+          second.data.tenant.subdomain
+        )
       })
     })
   },

--- a/app/src/api/store/tenants/route.ts
+++ b/app/src/api/store/tenants/route.ts
@@ -5,7 +5,7 @@ import TenantService from "../../../modules/tenant/service"
 
 export const CreateTenantSchema = z.object({
   owner_id: z.string(),
-  subdomain: z.string(),
+  subdomain: z.string().optional(),
 })
 
 type CreateTenantBody = z.infer<typeof CreateTenantSchema>
@@ -15,7 +15,7 @@ export async function POST(
   res: MedusaResponse
 ) {
   const tenantService: TenantService = req.scope.resolve(TENANT_MODULE)
-  const { owner_id, subdomain } = req.validatedBody
-  const tenant = await tenantService.createTenant(owner_id, subdomain)
+  const { owner_id } = req.validatedBody
+  const tenant = await tenantService.createTenant(owner_id)
   res.json({ tenant })
 }

--- a/app/src/modules/tenant/README.md
+++ b/app/src/modules/tenant/README.md
@@ -1,0 +1,6 @@
+# Tenant Module
+
+Handles tenant creation and retrieval.
+
+When creating a tenant through the Store API, the `subdomain` field is optional. If omitted, the service automatically generates a unique subdomain derived from the owner's identifier (for example, the email prefix) and appends a counter if needed to avoid collisions.
+


### PR DESCRIPTION
## Summary
- allow tenants to be created without a subdomain
- auto-generate unique subdomains based on owner info
- drop subdomain field from tenant signup and document behavior

## Testing
- `npm run test:unit -- --passWithNoTests`
- `npm run test:integration:http` *(fails: Error initializing database)*
- `npm run lint` *(fails: The "path" argument must be of type string)*

## PR Gate
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross‑module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).

------
https://chatgpt.com/codex/tasks/task_e_68c5d8fbe31083319bf3dd775ff24bac