### PR TITLE
feat(auth): add admin role and protect admin routes

### DIFF
--- a/app-storefront/src/lib/data/tenant.ts
+++ b/app-storefront/src/lib/data/tenant.ts
@@ -19,12 +19,17 @@ export async function tenantSignup(
     last_name: formData.get("last_name") as string,
     phone: formData.get("phone") as string,
   }
+  const role = (formData.get("role") as string | null)?.toLowerCase()
+  const roles = ["tenant"]
+  if (role === "admin") {
+    roles.push("admin")
+  }
 
   try {
     const token = await sdk.auth.register("user", "emailpass", {
       email: userForm.email,
       password,
-      roles: ["tenant"],
+      roles,
     })
 
     const payload = JSON.parse(

--- a/app/src/api/admin/invoice-config/route.ts
+++ b/app/src/api/admin/invoice-config/route.ts
@@ -6,6 +6,10 @@ export async function GET(
   req: MedusaRequest,
   res: MedusaResponse
 ) {
+  if (!req.actor?.roles?.includes("admin")) {
+    res.status(403).json({ message: "Forbidden" })
+    return
+  }
   const query = req.scope.resolve("query")
 
   const { data: [invoiceConfig] } = await query.graph({
@@ -33,6 +37,10 @@ export async function POST(
   req: MedusaRequest<PostInvoiceConfig>,
   res: MedusaResponse
 ) {
+  if (!req.actor?.roles?.includes("admin")) {
+    res.status(403).json({ message: "Forbidden" })
+    return
+  }
   const { result: { invoice_config } } = await updateInvoiceConfigWorkflow(req.scope)
     .run({
       input: req.validatedBody,

--- a/app/src/api/admin/orders/[id]/invoices/route.ts
+++ b/app/src/api/admin/orders/[id]/invoices/route.ts
@@ -5,6 +5,10 @@ export async function GET(
   req: MedusaRequest,
   res: MedusaResponse
 ): Promise<void> {
+  if (!req.actor?.roles?.includes("admin")) {
+    res.status(403).json({ message: "Forbidden" })
+    return
+  }
   const { id } = req.params
 
   const { result: {

--- a/app/src/api/admin/users/[id]/role/route.ts
+++ b/app/src/api/admin/users/[id]/role/route.ts
@@ -1,0 +1,20 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+
+export async function POST(
+  req: MedusaRequest,
+  res: MedusaResponse
+): Promise<void> {
+  if (!req.actor?.roles?.includes("admin")) {
+    res.status(403).json({ message: "Forbidden" })
+    return
+  }
+
+  const { id } = req.params
+  const userModuleService = req.scope.resolve(Modules.USER)
+  const [user] = await userModuleService.listUsers({ id })
+  const roles = Array.from(new Set([...(user.roles ?? []), "admin"]))
+  await userModuleService.updateUsers([{ id, roles }])
+  res.json({ id, roles })
+}
+


### PR DESCRIPTION
## Summary
- allow admin role during tenant signup
- guard admin endpoints with role checks
- add admin endpoint for promoting users to admin

## Testing
- ⚠️ `yarn lint` (Error while loading rule '@next/next/no-html-link-for-pages')
- ✅ `yarn test:unit --passWithNoTests`
- ⚠️ `yarn test:integration:http` (database initialization errors)

## PR Gate
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross‑module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c5dbd1f8448331aa6e51e465038751