### PR TITLE
feat(admin): manage tenants

### DIFF
--- a/app/integration-tests/http/tenant.spec.ts
+++ b/app/integration-tests/http/tenant.spec.ts
@@ -29,6 +29,22 @@ medusaIntegrationTestRunner({
           second.data.tenant.subdomain
         )
       })
+
+      it("lists, updates, and deletes tenants", async () => {
+        const tenantService = container.resolve(TENANT_MODULE)
+        const tenant = await tenantService.createTenant("owner3")
+
+        const tenants = await tenantService.listTenants()
+        expect(tenants.some((t) => t.id === tenant.id)).toBe(true)
+
+        await tenantService.updateTenant(tenant.id, { subdomain: "updated" })
+        const [updated] = await tenantService.listTenants({ id: tenant.id })
+        expect(updated.subdomain).toEqual("updated")
+
+        await tenantService.deleteTenant(tenant.id)
+        const after = await tenantService.listTenants({ id: tenant.id })
+        expect(after.length).toEqual(0)
+      })
     })
   },
 })

--- a/app/src/api/admin/tenants/route.ts
+++ b/app/src/api/admin/tenants/route.ts
@@ -1,0 +1,45 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { z } from "zod"
+import { TENANT_MODULE } from "../../../modules/tenant"
+import TenantService from "../../../modules/tenant/service"
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const tenantService: TenantService = req.scope.resolve(TENANT_MODULE)
+  const tenants = await tenantService.listTenants()
+  res.json({ tenants })
+}
+
+export const UpdateTenantSchema = z.object({
+  id: z.string(),
+  subdomain: z.string().optional(),
+  metadata: z.record(z.any()).optional(),
+})
+
+type UpdateTenantBody = z.infer<typeof UpdateTenantSchema>
+
+export async function PUT(
+  req: MedusaRequest<UpdateTenantBody>,
+  res: MedusaResponse
+) {
+  const tenantService: TenantService = req.scope.resolve(TENANT_MODULE)
+  const { id, ...data } = req.validatedBody
+  const tenant = await tenantService.updateTenant(id, data)
+  res.json({ tenant })
+}
+
+export const DeleteTenantSchema = z.object({
+  id: z.string(),
+})
+
+type DeleteTenantBody = z.infer<typeof DeleteTenantSchema>
+
+export async function DELETE(
+  req: MedusaRequest<DeleteTenantBody>,
+  res: MedusaResponse
+) {
+  const tenantService: TenantService = req.scope.resolve(TENANT_MODULE)
+  const { id } = req.validatedBody
+  await tenantService.deleteTenant(id)
+  res.json({ id, deleted: true })
+}
+

--- a/app/src/api/middlewares.ts
+++ b/app/src/api/middlewares.ts
@@ -1,6 +1,7 @@
-import { defineMiddlewares, validateAndTransformBody } from "@medusajs/framework/http"
+import { defineMiddlewares, validateAndTransformBody, authenticate } from "@medusajs/framework/http"
 import { PostInvoiceConfgSchema } from "./admin/invoice-config/route"
 import { CreateTenantSchema } from "./store/tenants/route"
+import { UpdateTenantSchema, DeleteTenantSchema } from "./admin/tenants/route"
 
 export default defineMiddlewares({
   routes: [
@@ -9,6 +10,29 @@ export default defineMiddlewares({
       methods: ["POST"],
       middlewares: [
         validateAndTransformBody(PostInvoiceConfgSchema)
+      ]
+    },
+    {
+      matcher: "/admin/tenants",
+      methods: ["GET"],
+      middlewares: [
+        authenticate("user", ["session", "bearer", "api-key"]),
+      ]
+    },
+    {
+      matcher: "/admin/tenants",
+      methods: ["PUT"],
+      middlewares: [
+        authenticate("user", ["session", "bearer", "api-key"]),
+        validateAndTransformBody(UpdateTenantSchema)
+      ]
+    },
+    {
+      matcher: "/admin/tenants",
+      methods: ["DELETE"],
+      middlewares: [
+        authenticate("user", ["session", "bearer", "api-key"]),
+        validateAndTransformBody(DeleteTenantSchema)
       ]
     },
     {

--- a/app/src/modules/tenant/service.ts
+++ b/app/src/modules/tenant/service.ts
@@ -4,6 +4,21 @@ import Tenant from "./models/tenant"
 class TenantService extends MedusaService({
   Tenant,
 }) {
+  async listTenants(selector: Record<string, any> = {}) {
+    return await super.listTenants(selector)
+  }
+
+  async updateTenant(
+    id: string,
+    data: Partial<{ subdomain?: string; owner_id?: string; metadata?: Record<string, any> }>
+  ) {
+    const [tenant] = await super.updateTenants({ id, ...data })
+    return tenant
+  }
+
+  async deleteTenant(id: string) {
+    await super.deleteTenants({ id })
+  }
   private sanitize(sub: string) {
     return sub
       .toLowerCase()


### PR DESCRIPTION
## Summary
- expose admin tenant route for list, update and delete
- extend tenant service with list/update/delete helpers
- secure admin tenant endpoints with role-based middlewares and add tests

## Testing
- `npm run test:integration:http` *(fails: Error initializing database)*

------
https://chatgpt.com/codex/tasks/task_e_68c5dd949e1c83319bedfcd53bb10b14