### PR TITLE
feat(app): ensure default admin user on startup

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,10 @@
+STORE_CORS=http://localhost:8000,https://docs.medusajs.com
+ADMIN_CORS=http://localhost:5173,http://localhost:9000,https://docs.medusajs.com
+AUTH_CORS=http://localhost:5173,http://localhost:9000,https://docs.medusajs.com
+REDIS_URL=redis://localhost:6379
+JWT_SECRET=supersecret
+COOKIE_SECRET=supersecret
+DATABASE_URL=
+DB_NAME=medusa-v2
+ADMIN_EMAIL=info@webmakerr.com
+ADMIN_PASSWORD=supersecret

--- a/app/src/loaders/create-admin-user.ts
+++ b/app/src/loaders/create-admin-user.ts
@@ -1,0 +1,34 @@
+import type { MedusaContainer } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys, Modules } from "@medusajs/framework/utils"
+
+export default async function ensureAdminUser({
+  container,
+}: {
+  container: MedusaContainer
+}): Promise<void> {
+  const logger = container.resolve(ContainerRegistrationKeys.LOGGER)
+  const userModuleService = container.resolve(Modules.USER)
+
+  const email = process.env.ADMIN_EMAIL || "info@webmakerr.com"
+  const password = process.env.ADMIN_PASSWORD
+
+  if (!password) {
+    logger.warn("ADMIN_PASSWORD is not set; skipping default admin creation")
+    return
+  }
+
+  const [existing] = await userModuleService.listUsers({ email })
+
+  if (!existing) {
+    await userModuleService.createUsers([{ email, password, roles: ["admin"] }])
+    logger.info(`Created default admin user ${email}`)
+    return
+  }
+
+  if (!existing.roles?.includes("admin")) {
+    const roles = Array.from(new Set([...(existing.roles ?? []), "admin"]))
+    await userModuleService.updateUsers([{ id: existing.id, roles }])
+    logger.info(`Updated roles for default admin user ${email}`)
+  }
+}
+


### PR DESCRIPTION
## Summary
- ensure default admin account exists on boot
- document admin credentials variables

## Testing
- `npm run test:unit` *(fails: No tests found)*

## PR Gate
- [x] Correctly chose **Module** or **Plugin** per the decision flow.
- [x] No cross-module imports; using container & links correctly.
- [x] Config via options; no secrets committed.
- [x] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c5df14e8248331b54047fa222cb8f8