### PR TITLE
feat(storefront): add tenant login flow

### DIFF
--- a/app-storefront/src/modules/tenant/components/login/index.tsx
+++ b/app-storefront/src/modules/tenant/components/login/index.tsx
@@ -5,10 +5,10 @@ import LocalizedClientLink from "@modules/common/components/localized-client-lin
 import Input from "@modules/common/components/input"
 import ErrorMessage from "@modules/checkout/components/error-message"
 import { SubmitButton } from "@modules/checkout/components/submit-button"
-import { login } from "@lib/data/customer"
+import { tenantLogin } from "@lib/data/tenant"
 
 const TenantLogin = () => {
-  const [message, formAction] = useActionState(login, null)
+  const [message, formAction] = useActionState(tenantLogin, null)
 
   return (
     <div className="max-w-sm flex flex-col items-center" data-testid="tenant-login-page">


### PR DESCRIPTION
## Summary
- add tenantLogin helper for tenant authentication and cart transfer
- wire tenant login component to new helper

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages')*
- `yarn build` *(fails: useSearchParams() should be wrapped in a suspense boundary)*
- `npx ts-node -e "import('./src/lib/data/tenant.ts').then(...)"` *(fails: Cannot find package 'ts-node')*

------
https://chatgpt.com/codex/tasks/task_e_68c5e85f718c83318ba6cca25c203bd3