### PR TITLE
fix(admin): allow app.webmakerr.com host

### DIFF
--- a/app/src/admin/vite.config.ts
+++ b/app/src/admin/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import medusaVitePlugin from "@medusajs/admin-vite-plugin";
+
+export default defineConfig({
+  plugins: [medusaVitePlugin(), react()],
+  server: {
+    allowedHosts: ["app.webmakerr.com"],
+  },
+});


### PR DESCRIPTION
## Summary
- allow app.webmakerr.com to connect to the admin dev server via Vite's allowedHosts

## Testing
- `npm run test:unit -- --passWithNoTests`

## PR Checklist
- [x] Correctly chose **Module** or **Plugin** per the decision flow.
- [x] No cross-module imports; using container & links correctly.
- [x] Config via options; no secrets committed.
- [x] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c5ef4740688331a26fe810c61ea073