### PR TITLE
feat(admin): allow tenant self-registration

### DIFF
--- a/app/integration-tests/http/admin-register.spec.ts
+++ b/app/integration-tests/http/admin-register.spec.ts
@@ -1,0 +1,30 @@
+import { medusaIntegrationTestRunner } from "@medusajs/test-utils"
+import { Modules } from "@medusajs/framework/utils"
+import { TENANT_MODULE } from "../../src/modules/tenant"
+
+jest.setTimeout(60 * 1000)
+
+medusaIntegrationTestRunner({
+  inApp: true,
+  env: { ADMIN_PASSWORD: "testadmin" },
+  testSuite: ({ api, container }) => {
+    describe("Admin registration", () => {
+      it("registers admin user and tenant", async () => {
+        const email = "newadmin@example.com"
+        const password = "password"
+
+        const response = await api.post("/admin/register", { email, password })
+        expect(response.status).toEqual(200)
+
+        const userService = container.resolve(Modules.USER)
+        const [user] = await userService.listUsers({ email })
+        expect(user?.roles).toContain("admin")
+
+        const tenantService = container.resolve(TENANT_MODULE)
+        const tenants = await tenantService.listTenants({ owner_id: user.id })
+        expect(tenants.length).toBeGreaterThan(0)
+        expect(tenants[0].owner_id).toEqual(user.id)
+      })
+    })
+  },
+})

--- a/app/src/api/admin/register/route.ts
+++ b/app/src/api/admin/register/route.ts
@@ -1,0 +1,28 @@
+import { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { Modules } from "@medusajs/framework/utils"
+import { z } from "zod"
+
+import { CreateAdminUserSchema } from "../users/route"
+import { TENANT_MODULE } from "../../../modules/tenant"
+import TenantService from "../../../modules/tenant/service"
+
+export const AdminRegisterSchema = CreateAdminUserSchema
+
+export type AdminRegisterBody = z.infer<typeof AdminRegisterSchema>
+
+export async function POST(
+  req: MedusaRequest<AdminRegisterBody>,
+  res: MedusaResponse
+) {
+  const userService = req.scope.resolve(Modules.USER)
+  const tenantService: TenantService = req.scope.resolve(TENANT_MODULE)
+
+  const [user] = await userService.createUsers([
+    { ...req.validatedBody, roles: ["admin"] },
+  ])
+
+  const tenant = await tenantService.createTenant(user.id)
+
+  res.json({ user, tenant })
+}
+

--- a/app/src/api/middlewares.ts
+++ b/app/src/api/middlewares.ts
@@ -10,6 +10,7 @@ import {
   DeleteTenantSchema,
 } from "./admin/tenants/route"
 import { CreateAdminUserSchema } from "./admin/users/route"
+import { AdminRegisterSchema } from "./admin/register/route"
 
 export default defineMiddlewares({
   routes: [
@@ -18,6 +19,13 @@ export default defineMiddlewares({
       methods: ["POST"],
       middlewares: [
         validateAndTransformBody(PostInvoiceConfgSchema)
+      ]
+    },
+    {
+      matcher: "/admin/register",
+      methods: ["POST"],
+      middlewares: [
+        validateAndTransformBody(AdminRegisterSchema)
       ]
     },
     {


### PR DESCRIPTION
## Summary
- allow store admins to self-register by exposing an unauthenticated `/admin/register` endpoint that creates both user and tenant
- validate requests and wire new route into API middleware
- add integration test for admin registration

## Testing
- `npm run test:unit -- --passWithNoTests`
- `npm run test:integration:http` *(fails: Error initializing database)*

## PR Gate
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c60676e0dc8331981c291f5da0eb62