### PR TITLE
fix: resolve admin registration plugin path

### DIFF
--- a/app/medusa-config.ts
+++ b/app/medusa-config.ts
@@ -1,4 +1,5 @@
 import { loadEnv, defineConfig } from "@medusajs/framework/utils";
+import path from "path";
 
 loadEnv(process.env.NODE_ENV || "development", process.cwd());
 
@@ -22,7 +23,8 @@ module.exports = defineConfig({
   },
   plugins: [
     {
-      resolve: "./src/plugins/admin-registration-link",
+      resolve: path.join(__dirname, "src/plugins/admin-registration-link"),
+      options: {},
     },
   ],
   modules: [


### PR DESCRIPTION
## Summary
- resolve admin-registration-link plugin using an absolute path and add empty options

## Testing
- `npm run build` *(fails: Property 'actor' does not exist on type 'MedusaRequest')*
- `npm run test:unit` *(fails: No tests found)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c60bc011b88331afce377ca00401dd