### PR TITLE
fix: use backend URL for admin registration

### DIFF
--- a/app/src/plugins/admin-registration-link/admin/routes/register/page.tsx
+++ b/app/src/plugins/admin-registration-link/admin/routes/register/page.tsx
@@ -30,7 +30,12 @@ export default function Register() {
 
   const handleSubmit = form.handleSubmit(async (values) => {
     setServerError(null)
-    const res = await fetch("/admin/register", {
+
+    const backendUrl =
+      (import.meta.env.VITE_MEDUSA_ADMIN_BACKEND_URL as string | undefined) ??
+      window.location.origin
+
+    const res = await fetch(new URL("/admin/register", backendUrl).toString(), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(values),


### PR DESCRIPTION
## Summary
- use configured backend URL when posting admin registration form

## Testing
- `npm run test:unit -- --passWithNoTests`
- `npm run test:integration:modules -- --passWithNoTests`
- `npm run test:integration:http -- --passWithNoTests` *(fails: Error initializing database)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c6110212508331ba97f7759351d716