### PR TITLE
fix: disable iframe scrolling in hero section

### DIFF
--- a/app-storefront/src/modules/home/components/hero/index.tsx
+++ b/app-storefront/src/modules/home/components/hero/index.tsx
@@ -44,13 +44,14 @@ const Hero = () => {
               height="321"
               src="https://ab9f9faf.sibforms.com/serve/MUIFAMMrfQVbv9lWk-rutNm5l4-bAEm0F30RuaKo-r_cMaSGMmk9nZWN462-P5yYBJ09TYEikHA0kebWFvLpIC2npJK0-nNTENNmKMTgmnk_zd78VC0qw3XowB_2kNiyiNO5Yr1wq-kJF9Y3-NBHEdZSKiUP9RUYltk7Ci0asd-nBbsNBPxsWh3h5V-e4Qnw_KNMc1sedtzEPID3"
               frameBorder="0"
-              scrolling="auto"
+              scrolling="no"
               allowFullScreen
               style={{
                 display: "block",
                 marginLeft: "auto",
                 marginRight: "auto",
                 maxWidth: "100%",
+                overflow: "hidden",
               }}
             />
           </div>


### PR DESCRIPTION
## Summary
- disable internal scrolling in hero iframe and hide overflow to keep content fixed

## Testing
- `npm run lint` (fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)

## PR Gate
- [ ] Correctly chose Module or Plugin per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c68cacbf64833192382b8b900e587f