### PR TITLE
fix(storefront): set newsletter iframe height

### DIFF
--- a/app-storefront/src/modules/home/components/hero/index.tsx
+++ b/app-storefront/src/modules/home/components/hero/index.tsx
@@ -41,7 +41,7 @@ const Hero = () => {
           <div className="flex flex-col gap-6 rounded-large border border-ui-border-base bg-ui-bg-base p-6 shadow-elevation-card-rest">
             <iframe
               width="388"
-              height="600"
+              height="450"
               src="https://ab9f9faf.sibforms.com/serve/MUIFAMMrfQVbv9lWk-rutNm5l4-bAEm0F30RuaKo-r_cMaSGMmk9nZWN462-P5yYBJ09TYEikHA0kebWFvLpIC2npJK0-nNTENNmKMTgmnk_zd78VC0qw3XowB_2kNiyiNO5Yr1wq-kJF9Y3-NBHEdZSKiUP9RUYltk7Ci0asd-nBbsNBPxsWh3h5V-e4Qnw_KNMc1sedtzEPID3"
               frameBorder="0"
               scrolling="no"


### PR DESCRIPTION
## Summary
- update newsletter iframe in home hero section to 450px tall

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in the lockfile)*

## PR Gate
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross‑module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c6bf1208c083319d7775c616318bf8