### PR TITLE
feat: add appointment booking thank-you page

### DIFF
--- a/app-storefront/next-sitemap.js
+++ b/app-storefront/next-sitemap.js
@@ -1,4 +1,4 @@
-const excludedPaths = ["/checkout", "/account/*"]
+const excludedPaths = ["/checkout", "/account/*", "/appointment/thank-you"]
 
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_VERCEL_URL,

--- a/app-storefront/src/app/[countryCode]/(main)/appointment/thank-you/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/appointment/thank-you/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: "Thank You for Booking",
+  description: "Appointment confirmation page",
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default function AppointmentThankYou() {
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col items-center justify-center px-4 py-32 text-center">
+      <h1 className="text-3xl font-semibold tracking-tight">Thank you for booking!</h1>
+      <p className="mt-4 text-base text-neutral-600">
+        We’ve received your appointment request and sent a confirmation to your
+        email.
+      </p>
+      <p className="mt-2 text-base text-neutral-600">
+        If you need to make any changes, please contact our support team.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add appointment booking thank-you page with noindex meta
- exclude page from sitemap

## Testing
- `npx next lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*
- `npx next build` *(fails: useSearchParams() should be wrapped in a suspense boundary at page "/404". Export encountered an error on /_not-found/page)*

## PR Checklist
- [x] Correctly chose **Module** or **Plugin** per the decision flow.
- [x] No cross-module imports; using container & links correctly.
- [x] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [x] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c6d1ae5248833198f24afdbdb00d7a