### PR TITLE
chore(app): exclude test files from build

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -23,5 +23,8 @@ if (process.env.TEST_TYPE === "integration:http") {
 } else if (process.env.TEST_TYPE === "integration:modules") {
   module.exports.testMatch = ["**/src/modules/*/__tests__/**/*.[jt]s"];
 } else if (process.env.TEST_TYPE === "unit") {
-  module.exports.testMatch = ["**/src/**/__tests__/**/*.unit.spec.[jt]s"];
+  module.exports.testMatch = [
+    "**/src/**/__tests__/**/*.unit.spec.[jt]s",
+    "**/src/__tests__/subscribers/**/*.unit.spec.[jt]s",
+  ];
 }

--- a/app/src/__tests__/subscribers/order-placed.unit.spec.ts
+++ b/app/src/__tests__/subscribers/order-placed.unit.spec.ts
@@ -1,4 +1,4 @@
-import orderPlacedHandler from "../order-placed"
+import orderPlacedHandler from "../../subscribers/order-placed"
 
 jest.mock("../../workflows/generate-invoice-pdf", () => ({
   generateInvoicePdfWorkflow: () => ({

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -30,6 +30,8 @@
     "node_modules",
     ".medusa/server",
     ".medusa/admin",
-    ".cache"
+    ".cache",
+    "src/**/__tests__",
+    "src/**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- avoid compiling test files by excluding them in tsconfig
- support new subscriber test location in jest config
- move order-placed subscriber unit test to central __tests__/ directory

## Testing
- `npm run test:unit`

- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross‑module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c6fa5ddc28833189d6e81dc0ec0e92