### PR TITLE
fix: ensure order confirmation emails send via Bravo

### DIFF
--- a/app/medusa-config.ts
+++ b/app/medusa-config.ts
@@ -26,13 +26,13 @@ export default defineConfig({
           {
             resolve: "./src/services/bravo",
             id: "bravo",
+            channels: ["email"],
             options: {
               api_key: process.env.BRAVO_API_KEY!,
               from: {
                 email: "info@webmakerr.com",
                 name: "Webmakerr",
               },
-              channels: ["email"],
             },
           },
         ],

--- a/app/src/__tests__/config/notification-config.unit.spec.ts
+++ b/app/src/__tests__/config/notification-config.unit.spec.ts
@@ -1,0 +1,15 @@
+import config from "../../../medusa-config"
+
+describe("notification plugin configuration", () => {
+  it("registers bravo provider for email channel", () => {
+    const notificationPlugin = (config.plugins || []).find(
+      (p) => p.resolve === "@medusajs/notification"
+    ) as any
+
+    const provider = notificationPlugin.options.providers.find(
+      (p: any) => p.id === "bravo"
+    )
+
+    expect(provider.channels).toContain("email")
+  })
+})


### PR DESCRIPTION
## Summary
- register Bravo notification provider for the email channel
- add config test for Bravo provider channel mapping

## Testing
- `npm run test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68c70c9710b08331b64f9fd77ed204bc