### PR TITLE
fix: process payment on first click

### DIFF
--- a/app-storefront/src/modules/checkout/components/payment-button/index.tsx
+++ b/app-storefront/src/modules/checkout/components/payment-button/index.tsx
@@ -68,16 +68,17 @@ const StripePaymentButton = ({
 
   const stripe = useStripe()
   const elements = useElements()
-  const card = elements?.getElement("card")
 
   const session = cart.payment_collection?.payment_sessions?.find(
     (s) => s.status === "pending"
   )
 
-  const disabled = !stripe || !elements ? true : false
+  const disabled = !stripe || !elements
 
   const handlePayment = async () => {
     setSubmitting(true)
+
+    const card = elements?.getElement("card")
 
     if (!stripe || !elements || !card || !cart) {
       setSubmitting(false)


### PR DESCRIPTION
## Summary
- ensure Stripe payment button retrieves card element when clicked to avoid requiring a second press

## Testing
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*
- `yarn build` *(fails: medusa-next@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c7b025a6a0833189c1ca2a777fc009