### PR TITLE
fix(account): update Webmakerr branding and signup fonts

### DIFF
--- a/app-storefront/src/app/[countryCode]/(main)/account/@dashboard/profile/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/account/@dashboard/profile/page.tsx
@@ -12,7 +12,7 @@ import { retrieveCustomer } from "@lib/data/customer"
 
 export const metadata: Metadata = {
   title: "Profile",
-  description: "View and edit your Medusa Store profile.",
+  description: "View and edit your Webmakerr profile.",
 }
 
 export default async function Profile() {
@@ -51,4 +51,3 @@ export default async function Profile() {
 const Divider = () => {
   return <div className="w-full h-px bg-gray-200" />
 }
-;``

--- a/app-storefront/src/app/[countryCode]/(main)/account/@login/page.tsx
+++ b/app-storefront/src/app/[countryCode]/(main)/account/@login/page.tsx
@@ -4,7 +4,7 @@ import LoginTemplate from "@modules/account/templates/login-template"
 
 export const metadata: Metadata = {
   title: "Sign in",
-  description: "Sign in to your Medusa Store account.",
+  description: "Sign in to your Webmakerr account.",
 }
 
 export default function Login() {

--- a/app-storefront/src/modules/account/components/register/index.tsx
+++ b/app-storefront/src/modules/account/components/register/index.tsx
@@ -7,6 +7,7 @@ import ErrorMessage from "@modules/checkout/components/error-message"
 import { SubmitButton } from "@modules/checkout/components/submit-button"
 import LocalizedClientLink from "@modules/common/components/localized-client-link"
 import { signup } from "@lib/data/customer"
+import { Heading, Text } from "@medusajs/ui"
 
 type Props = {
   setCurrentView: (view: LOGIN_VIEW) => void
@@ -20,13 +21,13 @@ const Register = ({ setCurrentView }: Props) => {
       className="max-w-sm flex flex-col items-center"
       data-testid="register-page"
     >
-      <h1 className="text-large-semi uppercase mb-6">
-        Become a Medusa Store Member
-      </h1>
-      <p className="text-center text-base-regular text-ui-fg-base mb-4">
-        Create your Medusa Store Member profile, and get access to an enhanced
+      <Heading level="h1" className="mb-6 uppercase text-large-semi">
+        Become a Webmakerr Member
+      </Heading>
+      <Text className="mb-4 text-center text-ui-fg-base">
+        Create your Webmakerr member profile, and get access to an enhanced
         shopping experience.
-      </p>
+      </Text>
       <form className="w-full flex flex-col" action={formAction}>
         <div className="flex flex-col w-full gap-y-2">
           <Input
@@ -68,8 +69,11 @@ const Register = ({ setCurrentView }: Props) => {
           />
         </div>
         <ErrorMessage error={message} data-testid="register-error" />
-        <span className="text-center text-ui-fg-base text-small-regular mt-6">
-          By creating an account, you agree to Medusa Store&apos;s{" "}
+        <Text
+          as="span"
+          className="mt-6 text-center text-ui-fg-base text-small-regular"
+        >
+          By creating an account, you agree to Webmakerr&apos;s{" "}
           <LocalizedClientLink
             href="/content/privacy-policy"
             className="underline"
@@ -84,12 +88,15 @@ const Register = ({ setCurrentView }: Props) => {
             Terms of Use
           </LocalizedClientLink>
           .
-        </span>
+        </Text>
         <SubmitButton className="w-full mt-6" data-testid="register-button">
           Join
         </SubmitButton>
       </form>
-      <span className="text-center text-ui-fg-base text-small-regular mt-6">
+      <Text
+        as="span"
+        className="mt-6 text-center text-ui-fg-base text-small-regular"
+      >
         Already a member?{" "}
         <button
           onClick={() => setCurrentView(LOGIN_VIEW.SIGN_IN)}
@@ -98,7 +105,7 @@ const Register = ({ setCurrentView }: Props) => {
           Sign in
         </button>
         .
-      </span>
+      </Text>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace Medusa Store references with Webmakerr on account pages
- align signup form typography with homepage using Heading and Text

## Testing
- `npx prettier src/app/[countryCode]/(main)/account/@login/page.tsx src/app/[countryCode]/(main)/account/@dashboard/profile/page.tsx src/modules/account/components/register/index.tsx --write`
- `yarn lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages': The "path" argument must be of type string. Received undefined)*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [x] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c7b9c6ac8083318c5150c10422c41d