### PR TITLE
feat: add digital download links for orders

### DIFF
--- a/app-storefront/src/lib/data/orders.ts
+++ b/app-storefront/src/lib/data/orders.ts
@@ -19,7 +19,7 @@ export const retrieveOrder = async (id: string) => {
       method: "GET",
       query: {
         fields:
-          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product",
+          "*payment_collections.payments,*items,*items.metadata,*items.variant,*items.product,*items.product.metadata",
       },
       headers,
       next,
@@ -49,7 +49,8 @@ export const listOrders = async (
         limit,
         offset,
         order: "-created_at",
-        fields: "*items,+items.metadata,*items.variant,*items.product",
+        fields:
+          "*items,+items.metadata,*items.variant,*items.product,*items.product.metadata",
         ...filters,
       },
       headers,

--- a/app-storefront/src/modules/order/components/item/index.tsx
+++ b/app-storefront/src/modules/order/components/item/index.tsx
@@ -12,6 +12,16 @@ type ItemProps = {
 }
 
 const Item = ({ item, currencyCode }: ItemProps) => {
+  const productMeta =
+    "product" in item
+      ? ((item as HttpTypes.StoreOrderLineItem).product?.metadata as
+          | Record<string, unknown>
+          | undefined)
+      : undefined
+  const downloadLink =
+    typeof productMeta?.download_link === "string"
+      ? (productMeta.download_link as string)
+      : null
   return (
     <Table.Row className="w-full" data-testid="product-row">
       <Table.Cell className="!pl-0 p-4 w-24">
@@ -28,6 +38,16 @@ const Item = ({ item, currencyCode }: ItemProps) => {
           {item.product_title}
         </Text>
         <LineItemOptions variant={item.variant} data-testid="product-variant" />
+        {downloadLink && (
+          <a
+            href={downloadLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-ui-fg-interactive text-small-regular block mt-2"
+          >
+            Download
+          </a>
+        )}
       </Table.Cell>
 
       <Table.Cell className="!pr-0">

--- a/app/src/subscribers/order-placed.ts
+++ b/app/src/subscribers/order-placed.ts
@@ -24,6 +24,9 @@ export default async function orderPlacedHandler({
         "items.*",
         "items.variant.*",
         "items.variant.product.*",
+        // Ensure we retrieve the product's metadata which may contain
+        // the digital download information
+        "items.variant.product.metadata",
         "shipping_address.*",
         "billing_address.*",
         "shipping_methods.*",
@@ -50,10 +53,23 @@ export default async function orderPlacedHandler({
   const base64 = buffer.toString("base64")
 
   const itemsList = order.items
-    .map(
-      (item) =>
-        `<li>${item.variant?.product?.title ?? item.title} x ${item.quantity}</li>`
-    )
+    .map((item) => {
+      const title = item.variant?.product?.title ?? item.title
+      const qty = item.quantity
+      const metadata = item.variant?.product?.metadata as
+        | Record<string, unknown>
+        | undefined
+      const link =
+        typeof metadata?.download_link === "string"
+          ? (metadata.download_link as string)
+          : null
+
+      const linkHtml = link
+        ? ` - <a href="${link}">Download</a>`
+        : ""
+
+      return `<li>${title} x ${qty}${linkHtml}</li>`
+    })
     .join("")
 
   const html = `<p>Thank you for your order!</p>


### PR DESCRIPTION
## Summary
- include digital download links in order confirmation emails
- expose product download links in order API responses
- surface download button on order items in account dashboard

## Testing
- `npm run test:unit`
- `npm run lint` *(fails: Error while loading rule '@next/next/no-html-link-for-pages')*

## PR Gate Checklist
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c7c07685f88331916e7b4fe5ba5355