### PR TITLE
feat(admin): add digital product download link

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -64,3 +64,7 @@ Join our [Discord server](https://discord.com/invite/medusajs) to meet other com
 ## Order Confirmation Emails
 
 This project sends order confirmation emails using the Bravo API. Set the `BRAVO_API_KEY` environment variable (see `.env.example`) with your Bravo API key to enable email notifications to buyers after checkout.
+
+## Digital Products
+
+Products can include a download link in their metadata. When provided, the link is added to order confirmation emails so customers can access their digital purchase.

--- a/app/src/admin/widgets/product-digital.tsx
+++ b/app/src/admin/widgets/product-digital.tsx
@@ -1,0 +1,30 @@
+import { defineWidgetConfig } from "@medusajs/admin-sdk"
+import { Container, Heading, Input, Label } from "@medusajs/ui"
+import { useFormContext } from "react-hook-form"
+
+const ProductDigitalWidget = () => {
+  const { register } = useFormContext()
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex items-center justify-between px-6 py-4">
+        <Heading level="h2">Digital Product</Heading>
+      </div>
+      <div className="flex flex-col gap-y-2 px-6 py-4">
+        <Label size="small" weight="plus">
+          Download link
+        </Label>
+        <Input
+          {...register("metadata.download_link")}
+          placeholder="https://example.com/download"
+        />
+      </div>
+    </Container>
+  )
+}
+
+export const config = defineWidgetConfig({
+  zone: "product.details.after",
+})
+
+export default ProductDigitalWidget


### PR DESCRIPTION
## Summary
- add widget to capture download link for digital products
- document how digital products are handled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:unit`
- `npm run test:integration:http` *(fails: TypeError: Cannot read properties of null (reading 'resolve'))*
- `npm run test:integration:modules` *(fails: No tests found, exiting with code 1)*
- `npm run build` *(fails: TS errors in subscribers/order-placed.ts)*

## PR Gate
- [ ] Correctly chose **Module** or **Plugin** per the decision flow.
- [ ] No cross-module imports; using container & links correctly.
- [ ] Config via options; no secrets committed.
- [ ] Loaders/migrations are idempotent.
- [ ] Tests added and passing (unit/integration as applicable).
- [ ] README includes install/config/usage with examples.
- [ ] Any UI changes reuse existing fonts/colors/styles only.
- [ ] (For plugins) CHANGELOG updated and semver applied.
- [ ] Storefront development followed official guidelines (if applicable).


------
https://chatgpt.com/codex/tasks/task_e_68c7c43a48488331bc8341b2a1f2f197